### PR TITLE
Add episode sampler for lyrics data

### DIFF
--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['episode', 'dataset', 'loaders']

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python3
+"""A dataset class lyrics and MIDI data for the few-shot-music-gen project
+"""
+import os
+
+import numpy as np
+
+
+class Dataset(object):
+    """A class for train/val/test sets.
+
+    This class is initialized with the following arguments:
+    Arguments:
+        root (str): the root directory of the dataset
+        split ("train", "val", or "test"): the split of the dataset which
+            this object represents.
+        loader (LyricsLoader or MIDILoader): the object used for reading and
+            parsing
+        split_proportions (tuple of three numbers): the unnormalized
+            (train, val, test) split.
+        persist (bool): persists the train/val/test split information in csv
+            files in `root`, so future runs will use the same splits. If those
+            csvs already exist, the sampler uses the splits from those files.
+    """
+    def __init__(self, root, split, loader, split_proportions=(8,1,1),
+            persist=True, cache=True):
+        self.root = root
+        self.cache = cache
+        self.cache_data = {}
+        self.loader = loader
+        split_csv_path = os.path.join(root, '%s.csv' % split)
+        if persist and os.path.exists(split_csv_path):
+            split_csv = open(split_csv_path, 'r')
+            self.artists = [line.strip() for line in split_csv.readlines()]
+            split_csv.close()
+        else:
+            dirs = []
+            for artist in os.listdir(root):
+                if os.path.isdir(os.path.join(root, artist)):
+                    dirs.append(artist)
+            artists = []
+            skipped_count = 0
+            for artist in dirs:
+                songs = os.listdir(os.path.join(root, artist))
+                songs = [song for song in songs if not os.path.isdir(song)]
+                if len(songs) >= support_size + query_size:
+                    artist_obj = Artist(name=artist, songs=songs)
+                    artists.append(artist_obj)
+                else:
+                    skipped_count += 1
+            if skipped_count > 0:
+                print("%s artists don't have K+K'=%s songs. Using %s artists" % (
+                    skipped_count, support_size + query_size, len(artists)))
+            artist_proportion = sum(split_proportions) * len(artists)
+            train_count = int(float(split_proportions[0]) / artist_proportion)
+            val_count = int(float(split_proportions[1]) / artist_proportion)
+            np.random.shuffle(artists)
+            if persist:
+                train_csv = open(os.path.join(root, 'train.csv'), 'w')
+                val_csv = open(os.path.join(root, 'val.csv'), 'w')
+                test_csv = open(os.path.join(root, 'test.csv'), 'w')
+                train_csv.write('\n'.join(artists[:train_count]))
+                val_csv.write('\n'.join(artists[train_count:train_count+val_count]))
+                test_csv.write('\n'.join(artists[train_count+val_count:]))
+                train_csv.close()
+                val_csv.close()
+                test_csv.close()
+            if split == 'train':
+                self.artists = artists[:train_count]
+            elif split == 'val':
+                self.artists = artists[train_count:train_count+val_count]
+            else:
+                self.artists = artists[train_count+val_count:]
+
+    def load(self, song, artist):
+        if self.cache and (song, artist) in self.cache_data:
+            return self.cache_data[(song, artist)]
+        else:
+            data = self.loader(os.path.join(self.root, song, artist))
+            self.cache_data[(song, artist)] = data
+            return data
+
+    def __len__(self):
+        return len(self.artists)
+
+    def __getitem__(self, index):
+        return self.artists[index]

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -48,8 +48,7 @@ class Dataset(object):
                 # filter out songs if they can't be loaded/parsed
                 songs = [song for song in songs if loader(song) is not None]
                 if len(songs) >= support_size + query_size:
-                    artist_obj = Artist(name=artist, songs=songs)
-                    artists.append(artist_obj)
+                    artists.append(artist)
                 else:
                     skipped_count += 1
             if skipped_count > 0:

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -58,7 +58,6 @@ class Dataset(object):
                     log.info("Preprocessing data. %s%%" % int(100*artist_index/num_dirs))
                     last_log = time.time()
                 songs = os.listdir(os.path.join(root, artist))
-                songs = [song for song in songs if not os.path.isdir(song)]
                 if len(songs) >= min_songs:
                     artists.append(artist)
                 else:

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -45,6 +45,8 @@ class Dataset(object):
             for artist in dirs:
                 songs = os.listdir(os.path.join(root, artist))
                 songs = [song for song in songs if not os.path.isdir(song)]
+                # filter out songs if they can't be loaded/parsed
+                songs = [song for song in songs if loader(song) is not None]
                 if len(songs) >= support_size + query_size:
                     artist_obj = Artist(name=artist, songs=songs)
                     artists.append(artist_obj)

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -21,6 +21,8 @@ class Dataset(object):
         persist (bool): persists the train/val/test split information in csv
             files in `root`, so future runs will use the same splits. If those
             csvs already exist, the sampler uses the splits from those files.
+        cache (bool): if true, caches the loaded/parsed songs in memory.
+            Otherwise it loads and parses songs on every episode.
     """
     def __init__(self, root, split, loader, split_proportions=(8,1,1),
             persist=True, cache=True):
@@ -51,6 +53,7 @@ class Dataset(object):
             if skipped_count > 0:
                 print("%s artists don't have K+K'=%s songs. Using %s artists" % (
                     skipped_count, support_size + query_size, len(artists)))
+            # normalize the splits to sum to 1
             artist_proportion = sum(split_proportions) * len(artists)
             train_count = int(float(split_proportions[0]) / artist_proportion)
             val_count = int(float(split_proportions[1]) / artist_proportion)
@@ -73,6 +76,12 @@ class Dataset(object):
                 self.artists = artists[train_count+val_count:]
 
     def load(self, song, artist):
+        """Read and parse `song` by `artist`.
+
+        Arguments:
+            song (str): the name of the song file. e.g. `"lateralus.txt"`
+            artist (str): the name of the artist directory. e.g. `"tool"`
+        """
         if self.cache and (song, artist) in self.cache_data:
             return self.cache_data[(song, artist)]
         else:

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -33,7 +33,7 @@ class Dataset(object):
             the dataset.
     """
     def __init__(self, root, split, loader, split_proportions=(8,1,1),
-            persist=True, cache=True, min_songs=9):
+            persist=True, cache=True, min_songs=0):
         self.root = root
         self.cache = cache
         self.cache_data = {}

--- a/src/data/episode.py
+++ b/src/data/episode.py
@@ -35,7 +35,6 @@ class SQSampler(object):
         else:
             artist_path = os.path.join(self.root, artist)
             songs = os.listdir(artist_path)
-            songs = [song for song in songs if not os.path.isdir(song)]
             if self.cache:
                 self.songs[artist] = songs
         sample = np.random.choice(

--- a/src/data/episode.py
+++ b/src/data/episode.py
@@ -1,0 +1,75 @@
+#!/usr/bin/python3
+import os
+import time
+import numpy as np
+
+
+class Episode(object):
+    def __init__(self, support, query):
+        self.support = support
+        self.query = query
+
+
+class SQSampler(object):
+    """A sampler for randomly sampling support/query sets.
+
+    Arguments:
+        root (str): the root of the data directory
+        support_size (int): number of songs in the support set
+        query_size (int): number of songs in the query set
+        cache (bool): caches the song names instead of hitting the FS
+    """
+    def __init__(self, root, support_size, query_size, cache=True):
+        self.root = root
+        self.support_size = support_size
+        self.query_size = query_size
+        self.cache = cache
+        if cache:
+            self.songs = {}
+
+    def sample(self, artist):
+        if self.cache and artist in self.songs:
+            songs = self.songs[artist]
+        else:
+            artist_path = os.path.join(root, artist)
+            songs = os.listdir(artist_path)
+            songs = [song for song in songs if not os.path.isdir(song)]
+            if self.cache:
+                self.songs[artist] = songs
+        sample = np.random.choice(
+            songs,
+            size=self.support_size+self.query_size,
+            replace=False)
+        query = sample[:self.query_size]
+        support = sample[self.query_size:]
+        return query, support
+
+
+class EpisodeSampler(object):
+    def __init__(self, dataset, batch_size, support_size, query_size, max_len):
+        self.dataset = dataset
+        self.batch_size = batch_size
+        self.support_size = support_size
+        self.query_size = query_size
+        self.max_len = max_len
+        self.sq_sampler = SQSampler(root, support_size, query_size)
+
+    def __len__(self):
+        return len(self.data)
+
+    def __repr__(self):
+        return 'EpisodeSampler("%s", "%s")' % (self.root, self.split)
+
+    def get_episode(self):
+        support = np.zeros((self.batch_size, self.support_size, max_len))
+        query = np.zeros((self.batch_size, self.query_size, max_len))
+        artists = np.random.choice(self.dataset, size=self.batch_size, replace=False)
+        for batch_index, artist in enumerate(artists):
+            support_songs, query_songs = self.sq_sampler.sample(artist)
+            for support_index, song in enumerate(support_songs):
+                parsed_song = self.dataset.load(artist, song)
+                support[batch_index,support_index,:] = parsed_song
+            for query_index, song in enumerate(query_songs):
+                parsed_song = self.dataset.load(artist, song)
+                support[batch_index,query_index,:] = parsed_song
+        return Episode(support, query)

--- a/src/data/episode.py
+++ b/src/data/episode.py
@@ -39,6 +39,9 @@ class SQSampler(object):
         else:
             artist_path = os.path.join(self.root, artist)
             songs = os.listdir(artist_path)
+            if len(songs) < self.query_size + self.support_size:
+                raise RuntimeError('artist "%s" does not have %s+%s songs.' % (
+                    artist, self.query_size, self.support_size))
             if self.cache:
                 self.songs[artist] = songs
         sample = np.random.choice(

--- a/src/data/loaders.py
+++ b/src/data/loaders.py
@@ -2,6 +2,9 @@
 """A module for lyrics and MIDI dataset loaders."""
 import os
 import numpy as np
+import logging
+
+log = logging.getLogger("few-shot")
 
 
 def tokenize_lyrics_file(filepath, max_len):

--- a/src/data/loaders.py
+++ b/src/data/loaders.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3
 """A module for lyrics and MIDI dataset loaders."""
-import os 
+import os
 import numpy as np
 
 
@@ -28,8 +28,7 @@ def tokenize_midi_file(filepath):
         filepath (str): path to the lyrics file. e.g.
             "/home/user/freemidi_data/Tool/lateralus.mid"
     """
-    midi_file = pretty_midi.PrettyMIDI(filepath)
-    return None
+    raise NotImplementedError
 
 
 class LyricsLoader(object):

--- a/src/data/loaders.py
+++ b/src/data/loaders.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python3
+"""A module for lyrics and MIDI dataset loaders."""
+import os 
+import numpy as np
+
+
+def tokenize_lyrics_file(filepath, max_len):
+    """Turns a file into a list of "words"
+
+    Arguments:
+        filepath (str): path to the lyrics file. e.g.
+            "/home/user/lyrics_data/tool/lateralus.txt"
+        max_len (int): the maximum length
+    """
+    token_count = 0
+    for line in open(filepath, 'r', errors='ignore'):
+        for token in line.split():
+            yield token
+            token_count += 1
+            if token_count >= max_len:
+                return
+
+
+def tokenize_midi_file(filepath):
+    """Turns a MIDI file into a list of event IDs.
+
+    Arguments:
+        filepath (str): path to the lyrics file. e.g.
+            "/home/user/freemidi_data/Tool/lateralus.mid"
+    """
+    midi_file = pretty_midi.PrettyMIDI(filepath)
+    return None
+
+
+class LyricsLoader(object):
+    """A class which loads and parses lyrics files into a list of word IDs.
+
+    Arguments:
+        length (int): maximum length of tokens, after witch to truncate. Songs
+            shorter than `length` are zero padded.
+        tokenize (function): a function which takes a single string argument
+            and returns a list of integer word IDs.
+        persist_file_name: (None or str): if not None, causes LyricsLoader to
+            load word IDs from and persist word IDs in the specified file.
+    """
+    def __init__(self, length, tokenize=tokenize_lyrics_file,
+            persist_file_name=None, dtype=np.int32):
+        self.length = length
+        self.tokenize = tokenize
+        self.word_ids = {}
+        self.highest_word_id = -1
+        self.dtype = dtype
+
+        # read persisted word ids
+        if persist_file_name is not None:
+            for line in open(persist_file_name, 'r'):
+                row = line.rstrip('\n').split(',', 1)
+                word_id = int(row[0])
+                self.word_ids[row[1]] = word_id
+                if word_id > self.highest_word_id:
+                    self.highest_word_id = word_id
+
+        if persist_file_name is not None:
+            self.persist_file = open(persist_file_name, 'w')
+        else:
+            self.persist_file = None
+
+    def __call__(self, filepath):
+        """This method takes some lyrics data and returns a list of integers
+        word IDs for that lyrics data.
+
+        Arguments:
+            filepath (str): specifies the path to the file to load.
+        """
+        tokens = self.tokenize(filepath, self.length)
+        word_ids = np.zeros(self.length, dtype=self.dtype)
+        for token_index, token in enumerate(tokens):
+            if token not in self.word_ids:
+                self.highest_word_id += 1
+                self.word_ids[token] = self.highest_word_id
+                if self.persist_file is not None:
+                    self.persist_file.write(
+                        '%s,%s\n' % (self.highest_word_id, token))
+            word_ids[token_index] = self.word_ids[token]
+        return word_ids
+
+    def close(self):
+        self.persist_file.close()
+
+
+class MIDILoader(object):
+    """A class which loads and parses MIDI files into a list of event IDs.
+
+    Arguments:
+        length (int): The length of the return value of `load`. If the MIDI
+            file is shorter than `length`, the remainder is zero padded.
+        tokenize (function): takes a MIDI file path and returns a list of
+            `length` length.
+        dtype (numpy data type): the numpy data type of the array returned by
+            `load`.
+    """
+    def __init__(self, length, tokenize=tokenize_midi_file, dtype=np.int32):
+        self.length = length
+        self.tokenize = tokenize
+        self.dtype = dtype
+
+    def __call__(self, filepath):
+        """This method takes a MIDI file path and returns a list of integer
+        event IDs.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
This commit adds an episode sampler for the lyrics data as a class
EpisodeSampler. The EpisodeSampler splits the dataset into three subsets
for training, validation, and testing. The information for the split can
be persisted and loaded for future runs with the same train/val/test
split.

Each episode randomly samples a batch of artists from the dataset. For
each artist, query and support batches of songs are sampled from the
dataset. If an artist does not have enough songs to fill the query and
support batches, they are skipped.

The lyrics are read from a directory structure following the pattern
`./[root dir]/[artist]/[song]`. After a song has been read, it is parsed
into a series of "words" or "tokens" (currently just by splitting on
whitespace). Each word is assigned an integer ID (which is optionally
persisted to a file). The sequence of word IDs is then transformed into
a numpy array, of a configurable length (zero-padded if the song is
shorter than the configured length).

As each song is numpy-ified, they are (optionally) cached in memory.
From benchmarks on my laptop, I've seen that this caching offers an
order of magnitude performance improvement for each call to
EpisodeSampler.get_episode().