### PR TITLE
Changes to Metadata class

### DIFF
--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -32,7 +32,7 @@ class Metadata(object):
         return os.path.exists(os.path.join(self.dir, filename))
 
     def lines(self, filename):
-        if self.exists(filename):
+        if self.exists(os.path.join(self.dir, filename)):
             for line in open(os.path.join(self.dir, filename), 'r'):
                 yield line
         else:

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -23,7 +23,7 @@ class Metadata(object):
     the sampler.
     """
     def __init__(self, root, name):
-        self.dir = os.path.join(root, 'few_shot_metadata_%s' % name)
+        self.dir = os.path.join(root, name)
         self.open_files = {}
         if not os.path.exists(self.dir):
             os.makedirs(self.dir)

--- a/src/data/dataset.py
+++ b/src/data/dataset.py
@@ -35,8 +35,6 @@ class Metadata(object):
         if self.exists(os.path.join(self.dir, filename)):
             for line in open(os.path.join(self.dir, filename), 'r'):
                 yield line
-        else:
-            return []
 
     def write(self, filename, line):
         if filename not in self.open_files:

--- a/src/data/lyrics_loader.py
+++ b/src/data/lyrics_loader.py
@@ -3,6 +3,7 @@
 """
 import logging
 import string
+import codecs
 
 import nltk
 import numpy as np
@@ -56,7 +57,7 @@ class LyricsLoader(Loader):
             filepath (str): path to the lyrics file. e.g.
                 "/home/user/lyrics_data/tool/lateralus.txt"
         """
-        return ''.join(open(filepath, 'r', errors='ignore').readlines())
+        return ''.join(codecs.open(filepath, 'r', errors='ignore').readlines())
 
     def tokenize(self, raw_lyrics):
         """Turns a string of lyrics data into a numpy array of int "word" IDs.


### PR DESCRIPTION
This PR makes two changes to the Metadata class:

1. It changes the metadata filename from `few_shot_metadata_few_shot_metadata_<etc>` to `few_shot_metadata_<etc>`.
2. It fixes a bug where the metadata object wouldn't read word_ids.csv unless it was in the local directory. This wouldn't be a problem if you preprocessed the entire dataset in one shot and you didn't care that highest_word_id was set correctly.